### PR TITLE
Add additional tests

### DIFF
--- a/test/Find-Member.Tests.ps1
+++ b/test/Find-Member.Tests.ps1
@@ -18,12 +18,27 @@ Describe 'Find-Member cmdlet tests' {
         }
 
         It 'filters passed members' {
-            $source = [type] | Find-Member
+            $source = [powershell] | Find-Member -Force
             $results = $source | Find-Member -Static
 
             $results | ShouldAll { $_ -in $source }
             $results.Count | Should -Not -Be $source.Count
         }
+    }
+
+    It 'gets all members with no input' {
+        $results = Find-Member
+        $results.Count | Should -BeGreaterThan 10000
+    }
+
+    It 'matches nonpublic members with Force' {
+        $result = $ExecutionContext.SessionState | Find-Member -Force
+
+        # A nonpublic member is present
+        $result | ShouldAny { $_.Name -eq 'Internal' -and 'Property' -eq $_.MemberType }
+
+        # A public member is still present
+        $result | ShouldAny { $_.Name -eq 'Module' -and 'Property' -eq $_.MemberType }
     }
 
     It 'matches with FilterScript' {
@@ -58,6 +73,31 @@ Describe 'Find-Member cmdlet tests' {
             ShouldAny { $_.Name -eq 'Create' }
     }
 
+    It 'return type matches constructors' {
+        [System.Collections.Generic.List[string]] |
+            Find-Member -ReturnType System.Collections.Generic.List[string] |
+            ShouldAny { 'Constructor' -eq $_.MemberType }
+    }
+
+    It 'unwraps target types with elements' {
+        $result = [System.Management.Automation.Language.Parser] |
+            Find-Member -ParameterType System.Management.Automation.Language.Token
+
+        $result | ShouldAny {
+            ($parameters = $_.GetParameters()) -and
+            $parameters[1].ParameterType.IsByRef -and
+            $parameters[1].ParameterType.GetElementType().IsArray
+        }
+    }
+
+    It 'return type matches fields' {
+        $contextType = Find-Type ExecutionContext -Namespace *Automation -Force
+        $result = $ExecutionContext | Find-Member -ReturnType $contextType -Force
+
+        $result.MemberType | Should -Be Field
+        $result.FieldType | Should -Be $contextType
+    }
+
     It 'filters to virtual members' {
         $results = [runspace] | Find-Member -Virtual
 
@@ -88,5 +128,16 @@ Describe 'Find-Member cmdlet tests' {
         $results | ShouldAll { $_.IsStatic -or $_.GetMethod.IsStatic }
         $results | ShouldAll { $_.Name -ne 'AddScript' }
         $results | ShouldAny { $_.Name -eq 'Create' }
+    }
+
+    It 'gets members for passed objects only once per type' {
+        $powershells = [powershell]::Create(), [powershell]::Create()
+        try {
+            $result = $powershells | Find-Member
+        } finally {
+            $powershells.ForEach('Dispose')
+        }
+
+        $result.Where{ $_.Name -eq 'Create' }.Count | Should -Be 3
     }
 }

--- a/test/Find-Type.Tests.ps1
+++ b/test/Find-Type.Tests.ps1
@@ -35,6 +35,22 @@ Describe 'Find-Type tests' {
     It 'matches by namespace' {
         Find-Type -Namespace System.Timers | ShouldAll { $_.Namespace -eq 'System.Timers' }
     }
+    It 'matches by full name' {
+        Find-Type -FullName System.Management.Automation.ProxyCommand |
+            Should -Be ([System.Management.Automation.ProxyCommand])
+    }
+    It 'matches by name with regex' {
+        Find-Type "Runspace(Factory|ConnectionInfo)" -RegularExpression |
+            Should -Be ([runspacefactory], [System.Management.Automation.Runspaces.RunspaceConnectionInfo])
+    }
+    It 'matches by namespace with regex' {
+        Find-Type -Namespace 'System.Xml.(XPath|Schema)' -Name Extensions -RegularExpression |
+            Should -Be ([System.Xml.Schema.Extensions], [System.Xml.XPath.Extensions])
+    }
+    It 'matches by full name with regex' {
+        Find-Type -FullName 'System\.(?!Threading)\w+\.Timer$' -RegularExpression |
+            Should -Be ([System.Timers.Timer])
+    }
     It 'matches by base class' {
         $results = Find-Type -InheritsType System.Management.Automation.Language.Ast
 

--- a/test/Find-Type.Tests.ps1
+++ b/test/Find-Type.Tests.ps1
@@ -44,8 +44,8 @@ Describe 'Find-Type tests' {
             Should -Be ([runspacefactory], [System.Management.Automation.Runspaces.RunspaceConnectionInfo])
     }
     It 'matches by namespace with regex' {
-        Find-Type -Namespace 'System.Xml.(XPath|Schema)' -Name Extensions -RegularExpression |
-            Should -Be ([System.Xml.Schema.Extensions], [System.Xml.XPath.Extensions])
+        Find-Type MethodAttributes -Namespace 'System\.(?!Reflection).+' -RegularExpression |
+            Should -Be ([System.Management.Automation.Language.MethodAttributes])
     }
     It 'matches by full name with regex' {
         Find-Type -FullName 'System\.(?!Threading)\w+\.Timer$' -RegularExpression |

--- a/test/Get-Parameter.Tests.ps1
+++ b/test/Get-Parameter.Tests.ps1
@@ -10,4 +10,9 @@ Describe 'Get-Parameter tests' {
 
         $results | ShouldAny { $_.Name -eq 'asyncResult' }
     }
+
+    It 'returns nothing without input' {
+        Get-Parameter | Should -BeNullOrEmpty
+        $null | Get-Parameter | Should -BeNullOrEmpty
+    }
 }


### PR DESCRIPTION
- Add tests for regex matching Name, Namespace, and FullName for types

- Add test for invoking `Find-Member` without input, finding nonpublic members, unwrapping `ByRef` and `Array` types during matching, and only retrieving members for unique types from piped objects.