### PR TITLE
Fix positional parameter binding for FilterScript

### DIFF
--- a/docs/en-US/Find-Member.md
+++ b/docs/en-US/Find-Member.md
@@ -12,6 +12,16 @@ Find properties, methods, fields, etc that fit specific criteria.
 
 ## SYNTAX
 
+### ByFilter (Default)
+
+```powershell
+Find-Member [-ParameterType <Type>] [-ReturnType <Type>] [-IncludeSpecialName] [-MemberType <MemberTypes>]
+ [-Static] [-Instance] [-Abstract] [-Virtual] [[-FilterScript] <ScriptBlock>] [-Name <String>] [-Force]
+ [-RegularExpression] [-InputObject <PSObject>]
+```
+
+### ByName
+
 ```powershell
 Find-Member [-ParameterType <Type>] [-ReturnType <Type>] [-IncludeSpecialName] [-MemberType <MemberTypes>]
  [-Static] [-Instance] [-Abstract] [-Virtual] [-FilterScript <ScriptBlock>] [[-Name] <String>] [-Force]
@@ -144,10 +154,20 @@ Specifies a ScriptBlock to invoke as a filter. The variable "$_" or "$PSItem" co
 
 ```yaml
 Type: ScriptBlock
-Parameter Sets: (All)
+Parameter Sets: ByFilter
 Aliases:
 
-Required: True
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+
+Type: ScriptBlock
+Parameter Sets: ByName
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -241,11 +261,21 @@ Specifies the member name to match.
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ByName
 Aliases:
 
 Required: False
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+
+Type: String
+Parameter Sets: ByFilter
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True

--- a/docs/en-US/Find-Type.md
+++ b/docs/en-US/Find-Type.md
@@ -12,9 +12,19 @@ Find .NET classes in the AppDomain.
 
 ## SYNTAX
 
+### ByFilter (Default)
+
 ```powershell
 Find-Type [[-Namespace] <String>] [-FullName <String>] [-InheritsType <Type>] [-ImplementsInterface <Type>]
- [[-Name] <String>] [-Abstract] [-Interface] [-ValueType] [-FilterScript <ScriptBlock>] [-Force]
+ [-Abstract] [-Interface] [-ValueType] [[-FilterScript] <ScriptBlock>] [-Name <String>] [-Force]
+ [-RegularExpression] [-InputObject <PSObject>]
+```
+
+### ByName
+
+```powershell
+Find-Type [[-Namespace] <String>] [-FullName <String>] [-InheritsType <Type>] [-ImplementsInterface <Type>]
+ [-Abstract] [-Interface] [-ValueType] [-FilterScript <ScriptBlock>] [[-Name] <String>] [-Force]
  [-RegularExpression] [-InputObject <PSObject>]
 ```
 
@@ -73,10 +83,20 @@ Specifies a ScriptBlock to invoke as a filter. The variable "$_" or "$PSItem" co
 
 ```yaml
 Type: ScriptBlock
-Parameter Sets: (All)
+Parameter Sets: ByFilter
 Aliases:
 
-Required: True
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+
+Type: ScriptBlock
+Parameter Sets: ByName
+Aliases:
+
+Required: False
 Position: Named
 Default value: None
 Accept pipeline input: False
@@ -169,11 +189,21 @@ Specifies the name of the type to match. For example, the name of the type "Syst
 
 ```yaml
 Type: String
-Parameter Sets: (All)
+Parameter Sets: ByName
 Aliases:
 
 Required: False
 Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+
+Type: String
+Parameter Sets: ByFilter
+Aliases:
+
+Required: False
+Position: Named
 Default value: None
 Accept pipeline input: False
 Accept wildcard characters: True

--- a/module/ClassExplorer.psd1
+++ b/module/ClassExplorer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ClassExplorer.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.0'
+ModuleVersion = '1.0.1'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'
@@ -88,7 +88,7 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        # ReleaseNotes = ''
+        ReleaseNotes = '- Fix positional binding of FilterScript for Find-Member and Find-Type.'
 
     } # End of PSData hashtable
 

--- a/src/ClassExplorer/Commands/FindMemberCommand.cs
+++ b/src/ClassExplorer/Commands/FindMemberCommand.cs
@@ -11,7 +11,7 @@ namespace ClassExplorer.Commands
     /// The Find-Member cmdlet searches the current AppDomain for matching members.
     /// </summary>
     [OutputType(typeof(MemberInfo))]
-    [Cmdlet(VerbsCommon.Find, "Member")]
+    [Cmdlet(VerbsCommon.Find, "Member", DefaultParameterSetName = "ByFilter")]
     public class FindMemberCommand : FindReflectionObjectCommandBase<MemberInfo>
     {
         private BindingFlags _flags;

--- a/src/ClassExplorer/Commands/FindReflectionObjectCommandBase.cs
+++ b/src/ClassExplorer/Commands/FindReflectionObjectCommandBase.cs
@@ -17,14 +17,16 @@ namespace ClassExplorer.Commands
         /// <summary>
         /// Gets or sets a ScriptBlock to invoke as a predicate filter.
         /// </summary>
-        [Parameter]
+        [Parameter(Position = 0, ParameterSetName="ByFilter")]
+        [Parameter(ParameterSetName="ByName")]
         [ValidateNotNull]
         public virtual ScriptBlock FilterScript { get; set; }
 
         /// <summary>
         /// Gets or sets the name to match.
         /// </summary>
-        [Parameter(Position = 0)]
+        [Parameter(Position = 0, ParameterSetName="ByName")]
+        [Parameter(ParameterSetName="ByFilter")]
         [SupportsWildcards]
         [ValidateNotNullOrEmpty]
         public virtual string Name { get; set; }

--- a/src/ClassExplorer/Commands/FindTypeCommand.cs
+++ b/src/ClassExplorer/Commands/FindTypeCommand.cs
@@ -12,7 +12,7 @@ namespace ClassExplorer.Commands
     /// The FindType cmdlet searches the AppDomain for matching types.
     /// </summary>
     [OutputType(typeof(Type))]
-    [Cmdlet(VerbsCommon.Find, "Type")]
+    [Cmdlet(VerbsCommon.Find, "Type", DefaultParameterSetName = "ByFilter")]
     public class FindTypeCommand : FindReflectionObjectCommandBase<Type>
     {
         /// <summary>
@@ -47,16 +47,6 @@ namespace ClassExplorer.Commands
         [ValidateNotNull]
         [ArgumentCompleter(typeof(TypeArgumentCompleter))]
         public Type ImplementsInterface { get; set; }
-
-        /// <summary>
-        /// Gets or sets the type name to match.
-        /// </summary>
-        [Parameter(Position = 0, ParameterSetName = "ByName")]
-        [Parameter(ParameterSetName = "__AllParameterSets")]
-        [ValidateNotNullOrEmpty]
-        [SupportsWildcards]
-        [ArgumentCompleter(typeof(TypeNameArgumentCompleter))]
-        public override string Name { get; set; }
 
         /// <summary>
         /// Gets or sets a value indicating whether to only match abstract classes.

--- a/src/ClassExplorer/Commands/FindTypeCommand.cs
+++ b/src/ClassExplorer/Commands/FindTypeCommand.cs
@@ -24,6 +24,16 @@ namespace ClassExplorer.Commands
         public string Namespace { get; set; }
 
         /// <summary>
+        /// Gets or sets the type name to match.
+        /// </summary>
+        [Parameter(Position = 0, ParameterSetName = "ByName")]
+        [Parameter(ParameterSetName = "ByFilter")]
+        [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
+        [ArgumentCompleter(typeof(TypeNameArgumentCompleter))]
+        public override string Name { get; set; }
+
+        /// <summary>
         /// Gets or sets the full type name to match.
         /// </summary>
         [Parameter]

--- a/src/ClassExplorer/TypeArgumentCompleter.cs
+++ b/src/ClassExplorer/TypeArgumentCompleter.cs
@@ -44,14 +44,6 @@ namespace ClassExplorer
             return GetTypesForCompletion(wordToComplete).Select(NewResult);
         }
 
-        private static bool CompletionTypeFilter(Type m, object filterCriteria)
-        {
-            return m.IsPublic &&
-                filterCriteria is string wordToComplete
-                    ? m.Name.StartsWith(wordToComplete, StringComparison.InvariantCultureIgnoreCase)
-                    : false;
-        }
-
         private static CompletionResult NewResult(Type type)
         {
             return new CompletionResult(

--- a/test/Completion.Tests.ps1
+++ b/test/Completion.Tests.ps1
@@ -20,6 +20,7 @@ Describe 'Completion tests' {
         $results = complete 'Find-Type -Name Toke'
 
         $results.CompletionMatches | ShouldAll { $_.CompletionText.StartsWith('Token') }
+        $results.CompletionMatches | Should -Not -BeNullOrEmpty
     }
     It 'can complete type full names' {
         $results = complete 'Find-Member -ReturnType Ast'

--- a/test/Find-Type.Tests.ps1
+++ b/test/Find-Type.Tests.ps1
@@ -51,7 +51,7 @@ Describe 'Find-Type tests' {
         $result | Should -Be ([powershell])
     }
     It 'matches by name' {
-        Find-Type runspace | Should -Be ([runspace])
+        Find-Type RunspaceMode | Should -Be ([System.Management.Automation.RunspaceMode])
     }
     It 'matches by namespace' {
         Find-Type -Namespace System.Timers | ShouldAll { $_.Namespace -eq 'System.Timers' }

--- a/test/Find-Type.Tests.ps1
+++ b/test/Find-Type.Tests.ps1
@@ -18,6 +18,27 @@ Describe 'Find-Type tests' {
             Get-Item . | Find-Type | Should -Be ([System.IO.DirectoryInfo])
         }
     }
+
+    Context 'Positional parameter binding' {
+        It 'accepts a scriptblock in position 0' {
+            Find-Type { $_.Name -eq 'runspace' } | Should -Be ([runspace])
+        }
+
+        It 'accepts a name in position 0' {
+            Find-Type RunspaceMode | Should -Be ([System.Management.Automation.RunspaceMode])
+        }
+
+        It 'accepts both a name and a script block as named parameters in the same command' {
+            Find-Type -Name Runspace* -FilterScript { $_.IsAbstract } |
+                ShouldAny { $_ -eq [runspace] }
+        }
+
+        It 'accepts namespace at position 1' {
+            Find-Type PowerShell* System.Management.Automation.Runspaces |
+                Should -Be ([System.Management.Automation.Runspaces.PowerShellProcessInstance])
+        }
+    }
+
     It 'can find all types' {
         $result = Find-Type | Measure-Object
 


### PR DESCRIPTION
- Change `Find-Member` and `Find-Type` to allow either `FilterScript`  or `Name` arguments to be in position 0 based on type.  (e.g. `Find-Type { $_.Name }` or `Find-Type Name`)

- Add tests for positional binding.

- Remove a method in `TypeArgumentCompleter` that was left in by mistake and isn't used.

- Fix a type name test that was invalid due to `Runspace` having a type accelerator.