### PR TITLE
Release 1.1.0

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,12 +3,12 @@ jobs:
     build:
         working_directory: ~/classexplorer
         docker:
-            - image: microsoft/powershell@sha256:6d36c498c1fdbb3ef42acabea1d06b12870e390fd3053993974ebaa6ba507849
+            - image: microsoft/powershell@sha256:c0bd0f7ad40bcc76130cb5e772515546e3d200f8a416a273b2605a942d9775f5
         steps:
             - checkout
             - run:
                 name: Run build script
-                command: 'powershell -File ./tools/InvokeCircleCI.ps1'
+                command: 'pwsh -File ./tools/InvokeCircleCI.ps1'
             - store_artifacts:
                 path: ./testresults/pester.xml
                 prefix: tests

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,16 +7,16 @@ install:
 - ps: >-
     Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
 
-    Install-Module Pester -RequiredVersion 4.0.6 -Scope CurrentUser -Force -SkipPublisherCheck
+    Install-Module Pester -RequiredVersion 4.1.1 -Scope CurrentUser -Force -SkipPublisherCheck
 
-    Install-Module InvokeBuild -RequiredVersion 3.2.1 -Scope CurrentUser -Force
+    Install-Module InvokeBuild -RequiredVersion 5.0.0 -Scope CurrentUser -Force
 
-    Install-Module platyPS -RequiredVersion 0.8.1 -Scope CurrentUser -Force
+    Install-Module platyPS -RequiredVersion 0.9.0 -Scope CurrentUser -Force
 
     choco install codecov --no-progress
 build_script:
 - ps: >-
-    Invoke-Build -Task Prerelease -Configuration Release -GenerateCodeCoverage
+    \& "$PWD\build.ps1" -Force
 
     $resultsFile = "$PWD\testresults\pester.xml"
 
@@ -30,3 +30,12 @@ build_script:
         $Error | Format-List * -Force
         exit 1;
     }
+on_finish:
+- ps: >-
+    Add-Type -AssemblyName System.IO.Compression.FileSystem
+
+    $zipPath = "$pwd\ClassExplorer.zip"
+
+    [System.IO.Compression.ZipFile]::CreateFromDirectory("$pwd\Release", $zipPath)
+
+    Push-AppveyorArtifact $zipPath

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -16,7 +16,7 @@ install:
     choco install codecov --no-progress
 build_script:
 - ps: >-
-    \& "$PWD\build.ps1" -Force
+    . "$PWD\build.ps1" -Force
 
     $resultsFile = "$PWD\testresults\pester.xml"
 

--- a/build.ps1
+++ b/build.ps1
@@ -1,0 +1,16 @@
+[CmdletBinding()]
+param(
+    [switch] $Force
+)
+end {
+    & "$PSScriptRoot\tools\AssertRequiredModule.ps1" InvokeBuild 5.0.0 -Force:$Force.IsPresent
+    $invokeBuildSplat = @{
+        Task = 'PreRelease'
+        File = "$PSScriptRoot/ClassExplorer.build.ps1"
+        GenerateCodeCoverage = $true
+        Force = $Force.IsPresent
+        Configuration = 'Release'
+    }
+
+    Invoke-Build @invokeBuildSplat
+}

--- a/docs/en-US/ClassExplorer.md
+++ b/docs/en-US/ClassExplorer.md
@@ -18,6 +18,10 @@ ClassExplorer is a PowerShell module that enables quickly searching the AppDomai
 
 The Find-Member cmdlet searches the AppDomain for members that fit specified criteria. You can search the entire AppDomain, search in specific types, or filter an existing list of members.
 
+### [Find-Namespace](Find-Namespace.md)
+
+The Find-Namespace cmdlet searches the AppDomain for namespaces that fit a specific criteria. You can search the entire AppDomain, specific assemblies, or get the namespace of specific types or members.
+
 ### [Find-Type](Find-Type.md)
 
 The Find-Type cmdlet searches the AppDomain for .NET classes that match specified criteria.

--- a/docs/en-US/Find-Member.md
+++ b/docs/en-US/Find-Member.md
@@ -119,7 +119,6 @@ Find-Member Parse* -ParameterType System.Management.Automation.Language.Token
 Find all members that start with the word Parse and take Token as a parameter. This example also
 demonstrates how this will even match the element of a type that is both an array and ByRef type.
 
-
 ### -------------------------- EXAMPLE 5 --------------------------
 
 ```powershell
@@ -281,6 +280,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -Not
+
+Specifies that this cmdlet should only return object that do not match the criteria.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -ParameterType
 
 Specifies a type that a member must accept as a parameter to be matched. This parameter will also match base types, implemented interfaces, and the element type of array, byref, pointer and generic types.
@@ -363,11 +378,13 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### Type, MemberInfo, PSObject
+### ClassExplorer.NamespaceInfo, System.Type, System.Reflection.MemberInfo, PSObject
+
+If you pass NamespaceInfo objects to this cmdlet it will match members from types declared in that namespace.
 
 If you pass Type objects to this cmdlet it will match members from that type.
 
-If you pass MemberInfo objects to this cmdlet it will filter them.
+If you pass MemberInfo objects as input this cmdlet will return the input if it matches the specified criteria.  You can use this to chain Find-Member commands to filter output.
 
 If you pass any other type to this cmdlet it will match members from that object's type.
 
@@ -382,5 +399,6 @@ Matched MemberInfo objects will be returned to the pipeline.
 ## RELATED LINKS
 
 [Find-Type](Find-Type.md)
+[Find-Namespace](Find-Namespace.md)
 [Get-Assembly](Get-Assembly.md)
 [Get-Parameter](Get-Parameter.md)

--- a/docs/en-US/Find-Namespace.md
+++ b/docs/en-US/Find-Namespace.md
@@ -1,0 +1,251 @@
+---
+external help file: ClassExplorer.dll-Help.xml
+Module Name: ClassExplorer
+online version: https://github.com/SeeminglyScience/ClassExplorer/blob/master/docs/en-US/Find-Namespace.md
+schema: 2.0.0
+---
+
+# Find-Namespace
+
+## SYNOPSIS
+
+Find namespaces that fit specific criteria.
+
+## SYNTAX
+
+### ByFilter (Default)
+
+```powershell
+Find-Namespace [[-Name] <String>] [-FullName <String>] [[-FilterScript] <ScriptBlock>] [-Force]
+ [-RegularExpression] [-InputObject <PSObject>] [-Not] [<CommonParameters>]
+```
+
+### ByName
+
+```powershell
+Find-Namespace [[-Name] <String>] [-FullName <String>] [[-FilterScript] <ScriptBlock>] [-Force]
+ [-RegularExpression] [-InputObject <PSObject>] [-Not] [<CommonParameters>]
+```
+
+## DESCRIPTION
+
+The Find-Namespace cmdlet searches the AppDomain for namespaces that fit a specific criteria. You can search the entire AppDomain, specific assemblies, or get the namespace of specific types or members.
+
+## EXAMPLES
+
+### -------------------------- EXAMPLE 1 --------------------------
+
+```powershell
+Find-Namespace Automation
+
+# Name                 FullName                                 Assemblies
+# ----                 --------                                 ----------
+# Automation           System.Management.Automation             System.Management.Automation
+```
+
+Find any namespaces with the name "Automation"
+
+### -------------------------- EXAMPLE 2 --------------------------
+
+```powershell
+Get-Assembly System.Xml | Find-Namespace
+
+# Name                 FullName                                 Assemblies
+# ----                 --------                                 ----------
+# Xml                  System.Xml                               System.Xml, System.Data
+# Serialization        System.Xml.Serialization                 System.Xml
+# Configuration        System.Xml.Serialization.Configuration   System.Xml
+# Advanced             System.Xml.Serialization.Advanced        System.Xml
+# Schema               System.Xml.Schema                        System.Xml, System.Xml.Linq
+# Xsl                  System.Xml.Xsl                           System.Xml
+# XPath                System.Xml.XPath                         System.Xml, System.Xml.Linq
+# Resolvers            System.Xml.Resolvers                     System.Xml
+# XmlConfiguration     System.Xml.XmlConfiguration              System.Xml
+```
+
+Get the assembly with the assembly name "System.Xml" and find all namespaces that it declares types in.
+
+### -------------------------- EXAMPLE 3 --------------------------
+
+```powershell
+Find-Namespace { Find-Member -InputObject $_ -Static -ParameterType runspace }
+
+# Name                 FullName                        Assemblies
+# ----                 --------                        ----------
+# PowerShell           Microsoft.PowerShell            Microsoft.PowerShell.ConsoleHost, System...
+# Automation           System.Management.Automation    System.Management.Automation
+```
+
+Find any namespace that has a static member that takes a parameter of the type `runspace`.
+
+### -------------------------- EXAMPLE 4 --------------------------
+
+```powershell
+$namespaces = Find-Namespace -FullName *management*
+$namespaces | Find-Namespace -FullName 'Microsoft|Internal' -RegularExpression -Not
+
+# Name                 FullName                                 Assemblies
+# ----                 --------                                 ----------
+# Instrumentation      System.Management.Instrumentation        System.Core, System.Management
+# Automation           System.Management.Automation             System.Management.Automation
+# PerformanceData      System.Management.Automation.Performa... System.Management.Automation
+# Tracing              System.Management.Automation.Tracing     System.Management.Automation
+# Security             System.Management.Automation.Security    System.Management.Automation
+# Provider             System.Management.Automation.Provider    System.Management.Automation
+# Remoting             System.Management.Automation.Remoting    System.Management.Automation
+# WSMan                System.Management.Automation.Remoting... System.Management.Automation
+# Host                 System.Management.Automation.Host        System.Management.Automation
+# Runspaces            System.Management.Automation.Runspaces   System.Management.Automation
+# Language             System.Management.Automation.Language    System.Management.Automation
+# Management           System.Management                        System.Management
+# Management           System.Web.Management                    System.Web.Extensions, System.Web
+```
+
+First find all namespaces with the word "management" in their full name, then filter it by namespaces
+that do not contain "Microsoft" or "Internal" in their full name.
+
+## PARAMETERS
+
+### -FilterScript
+
+Specifies a ScriptBlock to invoke as a filter. The variable "$_" or "$PSItem" contains the current NamespaceInfo object to evaluate.
+
+```yaml
+Type: ScriptBlock
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -Force
+
+If specified non-public namespaces will also be matched. Currently this has no effect.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: IncludeNonPublic, F
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -FullName
+
+Specifies the full namespace name to match.
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -InputObject
+
+Specifies the current object to evaluate.
+
+```yaml
+Type: PSObject
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: True (ByValue)
+Accept wildcard characters: False
+```
+
+### -Name
+
+Specifies the namespace name to match.  The name in this context is the last section of namespace.  For instance, if the namespace was "System.Management.Automation", the name would be "Automation".
+
+```yaml
+Type: String
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: 0
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: True
+```
+
+### -Not
+
+Specifies that this cmdlet should only return object that do not match the criteria.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RegularExpression
+
+If specified any parameter that accepts wildcards will switch to matching regular expressions.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: Regex
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### CommonParameters
+
+This cmdlet supports the common parameters: -Debug, -ErrorAction, -ErrorVariable, -InformationAction, -InformationVariable, -OutVariable, -OutBuffer, -PipelineVariable, -Verbose, -WarningAction, and -WarningVariable.
+For more information, see about_CommonParameters (http://go.microsoft.com/fwlink/?LinkID=113216).
+
+## INPUTS
+
+### ClassExplorer.NamespaceInfo, System.Reflection.AssemblyInfo, System.Type, System.Reflection.MemberInfo, PSObject
+
+If you pass NamespaceInfo objects as input this cmdlet will return the input if it matches the specified criteria.  You can use this to chain Find-Namespace commands to filter output.
+
+If you pass AssemblyInfo objects as input this cmdlet will return namespaces from that assembly.
+
+If you pass Type or MemberInfo objects as input this cmdlet will return the namespace of that type or member.
+
+If you pass any other object the namespace of that object's type will be returned.
+
+## OUTPUTS
+
+### ClassExplorer.NamespaceInfo
+
+Matched NamespaceInfo objects will be returned to the pipeline.
+
+## NOTES
+
+## RELATED LINKS
+
+[Find-Type](Find-Type.md)
+[Find-Member](Find-Member.md)
+[Get-Assembly](Get-Assembly.md)
+[Get-Parameter](Get-Parameter.md)

--- a/docs/en-US/Find-Type.md
+++ b/docs/en-US/Find-Type.md
@@ -225,6 +225,22 @@ Accept pipeline input: False
 Accept wildcard characters: True
 ```
 
+### -Not
+
+Specifies that this cmdlet should only return object that do not match the criteria.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases:
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
 ### -RegularExpression
 
 If specified all parameters that accept wildcards will match regular expressions instead.
@@ -243,11 +259,13 @@ Accept wildcard characters: False
 
 ## INPUTS
 
-### System.Reflection.Assembly, System.Type, System.Management.Automation.PSObject
+### ClassExplorer.NamespaceInfo, System.Reflection.Assembly, System.Type, PSObject
+
+If you pass NamespaceInfo objects to this cmdlet it will match types declared in that namespace.
 
 If you pass assemblies to this cmdlet it will match types from that assembly.
 
-If you pass types to this cmdlet it will filter the passed types.
+If you pass Type objects as input this cmdlet will return the input if it matches the specified criteria.  You can use this to chain Find-Type commands to filter output.
 
 If you pass any other object to this cmdlet it will return the type of that object.
 
@@ -262,5 +280,6 @@ Matched Type objected will be returned to the pipeline.
 ## RELATED LINKS
 
 [Find-Member](Find-Member.md)
+[Find-Namespace](Find-Namespace.md)
 [Get-Assembly](Get-Assembly.md)
 [Get-Parameter](Get-Parameter.md)

--- a/docs/en-US/Get-Assembly.md
+++ b/docs/en-US/Get-Assembly.md
@@ -81,4 +81,5 @@ Matched Assembly objects will be returned to the pipeline.
 
 [Find-Type](Find-Type.md)
 [Find-Member](Find-Member.md)
+[Find-Namespace](Find-Namespace.md)
 [Get-Parameter](Get-Parameter.md)

--- a/docs/en-US/Get-Parameter.md
+++ b/docs/en-US/Get-Parameter.md
@@ -78,4 +78,5 @@ Matched parameters will be returned to the pipeline.
 
 [Find-Type](Find-Type.md)
 [Find-Member](Find-Member.md)
+[Find-Namespace](Find-Namespace.md)
 [Get-Assembly](Get-Assembly.md)

--- a/module/ClassExplorer.psd1
+++ b/module/ClassExplorer.psd1
@@ -12,7 +12,7 @@
 RootModule = 'ClassExplorer.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.0.1'
+ModuleVersion = '1.1.0'
 
 # Supported PSEditions
 CompatiblePSEditions = 'Desktop', 'Core'
@@ -48,7 +48,7 @@ ProcessorArchitecture = 'None'
 FunctionsToExport = @()
 
 # Cmdlets to export from this module, for best performance, do not use wildcards and do not delete the entry, use an empty array if there are no cmdlets to export.
-CmdletsToExport = 'Find-Member', 'Find-Type', 'Get-Assembly', 'Get-Parameter'
+CmdletsToExport = 'Find-Member', 'Find-Type', 'Find-Namespace', 'Get-Assembly', 'Get-Parameter'
 
 # Variables to export from this module
 VariablesToExport = @()

--- a/module/ClassExplorer.psd1
+++ b/module/ClassExplorer.psd1
@@ -88,7 +88,40 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '- Fix positional binding of FilterScript for Find-Member and Find-Type.'
+        ReleaseNotes = @'
+# Version 1.1.0
+
+## Find-Namespace Cmdlet
+
+Added the `Find-Namespace` cmdlet for searching the AppDomain for specific namespaces.  This is
+paticularly useful when exploring a new assembly to get a quick idea what's available. The namespace
+objects returned from this cmdlet can be piped into `Find-Type` or `Find-Member`.
+
+## More argument completion
+
+Namespace parameters for `Find-Namespace` and `Find-Type` now have tab completion. The `Name` parameter
+for `Get-Assembly` will now also complete assembly names.
+
+## Not parameter
+
+The cmdlets `Find-Namespace`, `Find-Type`, and `Find-Member` now have a `Not` parameter to negate the
+search criteria. This makes chaining the commands to filter results a lot easier. Here's a basic example.
+
+```powershell
+Find-Namespace Automation | Find-Member -Static | Find-Member -MemberType Field -Not
+```
+
+## Fixes
+
+- The `Find-*` cmdlets no longer return all matches in the AppDomain if passed null pipeline input
+
+- Added support for explicitly specifying the `InputObject` parameter from pipeline position 0
+
+- `Find-Type` no longer throws when the `Namespace` parameter is specified with the `RegularExpression`
+  switch parameter
+
+- Various build and test fixes
+'@
 
     } # End of PSData hashtable
 

--- a/src/ClassExplorer/AssemblyNameArgumentCompleter.cs
+++ b/src/ClassExplorer/AssemblyNameArgumentCompleter.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace ClassExplorer
+{
+    /// <summary>
+    /// Provides argument completion for assembly name input parameters.
+    /// </summary>
+    public class AssemblyNameArgumentCompleter : IArgumentCompleter
+    {
+        private static Lazy<HashSet<string>> s_cachedAssemblyNames =
+            new Lazy<HashSet<string>>(LoadAssemblyNames);
+
+        /// <summary>
+        /// Called by the PowerShell engine to complete a parameter.
+        /// </summary>
+        /// <param name="commandName">The name of the command.</param>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <param name="wordToComplete">The current parameter value.</param>
+        /// <param name="commandAst">The AST of the command.</param>
+        /// <param name="fakeBoundParameters">A dictionary of currently bound parameters.</param>
+        /// <returns>The result of completion.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters)
+        {
+            return s_cachedAssemblyNames.Value
+                .Where(name => name.StartsWith(wordToComplete, StringComparison.CurrentCultureIgnoreCase))
+                .Select(
+                    name => new CompletionResult(
+                        name,
+                        name,
+                        CompletionResultType.ParameterValue,
+                        name));
+        }
+
+        private static HashSet<string> LoadAssemblyNames()
+        {
+            AppDomain.CurrentDomain.AssemblyLoad += AppDomain_OnAssemblyLoad;
+            try
+            {
+                return
+                    new HashSet<string>(
+                        AppDomain
+                            .CurrentDomain
+                            .GetAssemblies()
+                            .Select(assembly => assembly.GetName().Name));
+            }
+            catch (Exception)
+            {
+                // TODO: Better handling
+                AppDomain.CurrentDomain.AssemblyLoad -= AppDomain_OnAssemblyLoad;
+                throw;
+            }
+        }
+
+        private static void AppDomain_OnAssemblyLoad(object source, AssemblyLoadEventArgs e)
+        {
+            s_cachedAssemblyNames.Value.Add(e.LoadedAssembly.GetName().Name);
+        }
+    }
+}

--- a/src/ClassExplorer/Commands/FindNamespaceCommand.cs
+++ b/src/ClassExplorer/Commands/FindNamespaceCommand.cs
@@ -1,0 +1,186 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using static ClassExplorer.FilterFrame<ClassExplorer.NamespaceInfo>;
+
+namespace ClassExplorer.Commands
+{
+    /// <summary>
+    /// The Find-Namespace cmdlet searches the AppDomain for matching namespaces.
+    /// </summary>
+    [Cmdlet(VerbsCommon.Find, "Namespace", DefaultParameterSetName = "ByFilter")]
+    [OutputType(typeof(NamespaceInfo))]
+    public class FindNamespaceCommand : FindReflectionObjectCommandBase<NamespaceInfo>
+    {
+        private static HashSet<string> _processedNamespaces = new HashSet<string>();
+
+        /// <summary>
+        /// Gets or sets the name of the namespace to match.
+        /// </summary>
+        [Parameter(Position = 0, ParameterSetName = "ByName")]
+        [Parameter(ParameterSetName = "ByFilter")]
+        [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
+        [ArgumentCompleter(typeof(NamespaceNameArgumentCompleter))]
+        public override string Name { get; set; }
+
+        /// <summary>
+        /// Gets or sets the full name of the namespace to match.
+        /// </summary>
+        [Parameter]
+        [ValidateNotNullOrEmpty]
+        [SupportsWildcards]
+        [ArgumentCompleter(typeof(NamespaceArgumentCompleter))]
+        public string FullName { get; set; }
+
+        /// <summary>
+        /// Process parameters and create the filter list.
+        /// </summary>
+        protected override void InitializeFilters()
+        {
+            ProcessName(Name, WildcardNameFilter, RegexNameFilter);
+            ProcessName(FullName, WildcardNamespaceFilter, RegexNamespaceFilter);
+            if (FilterScript != null)
+            {
+                var filter = new ReflectionFilter(
+                    (ns, criteria) =>
+                    {
+                        return LanguagePrimitives.IsTrue(
+                            FilterScript.InvokeWithContext(
+                                null,
+                                new List<PSVariable>() { new PSVariable("_", ns) },
+                                ns));
+                    });
+                ProcessParameter(filter, true);
+            }
+        }
+
+        /// <summary>
+        /// The EndProcessing method.
+        /// </summary>
+        protected override void EndProcessing()
+        {
+            if (ExpectingInput)
+            {
+                return;
+            }
+
+            if (!(RegularExpression.IsPresent ||
+                string.IsNullOrWhiteSpace(FullName) ||
+                WildcardPattern.ContainsWildcardCharacters(FullName)))
+            {
+                if (NamespaceInfo.Namespaces.TryGetValue(FullName, out NamespaceInfo ns))
+                {
+                    WriteObject(ns);
+                }
+
+                return;
+            }
+
+            WriteObject(
+                NamespaceInfo
+                    .GetNamespaces()
+                    .Where(ns => AggregateFilter(ns, null)),
+                enumerateCollection: true);
+        }
+
+        /// <summary>
+        /// A filter that matches only public namespaces. This currently always returns true.
+        /// </summary>
+        /// <param name="m">The namepsace to test for a match.</param>
+        /// <param name="filterCriteria">The parameter is not used.</param>
+        /// <returns>A value indicating whether the object matches.</returns>
+        protected override bool PublicFilter(NamespaceInfo m, object filterCriteria)
+        {
+            return true;
+        }
+
+        /// <summary>
+        /// The ProcessSingleObject method.
+        /// </summary>
+        /// <param name="input">The input parameter from the pipeline.</param>
+        protected override void ProcessSingleObject(PSObject input)
+        {
+            if (input.BaseObject == null)
+            {
+                return;
+            }
+
+            if (input.BaseObject is NamespaceInfo)
+            {
+                base.ProcessSingleObject(input);
+                return;
+            }
+
+            if (input.BaseObject is Assembly assembly)
+            {
+                WriteObject(
+                    NamespaceInfo
+                        .GetNamespaces()
+                        .Where(ns => ns.Assemblies.Contains(assembly) && AggregateFilter(ns, null)),
+                    enumerateCollection: true);
+                return;
+            }
+
+            if (input.BaseObject is Type type)
+            {
+                ProcessSingleNamespace(type.Namespace);
+                return;
+            }
+
+            if (input.BaseObject is MemberInfo member)
+            {
+                ProcessSingleNamespace(member.ReflectedType.Namespace);
+                return;
+            }
+
+            ProcessSingleNamespace(input.BaseObject.GetType().Namespace);
+        }
+
+        private static bool WildcardNamespaceFilter(NamespaceInfo m, object filterCriteria)
+        {
+            WildcardPattern pattern = filterCriteria as WildcardPattern;
+
+            return pattern == null ? false : pattern.IsMatch(m.FullName);
+        }
+
+        private static bool RegexNamespaceFilter(NamespaceInfo m, object filterCriteria)
+        {
+            Regex pattern = filterCriteria as Regex;
+
+            return !string.IsNullOrWhiteSpace(m.FullName) &&
+                pattern == null ? false : pattern.IsMatch(m.FullName);
+        }
+
+        private bool ProcessSingleNamespace(string ns)
+        {
+            if (string.IsNullOrWhiteSpace(ns))
+            {
+                return false;
+            }
+
+            if (_processedNamespaces.Contains(ns))
+            {
+                return false;
+            }
+
+            NamespaceInfo existing;
+            if (!NamespaceInfo.Namespaces.TryGetValue(ns, out existing))
+            {
+                return false;
+            }
+
+            if (!AggregateFilter(existing, null))
+            {
+                return false;
+            }
+
+            _processedNamespaces.Add(ns);
+            WriteObject(existing);
+            return true;
+        }
+    }
+}

--- a/src/ClassExplorer/Commands/GetAssemblyCommand.cs
+++ b/src/ClassExplorer/Commands/GetAssemblyCommand.cs
@@ -18,6 +18,7 @@ namespace ClassExplorer.Commands
         [Parameter(Position = 0)]
         [ValidateNotNullOrEmpty]
         [SupportsWildcards]
+        [ArgumentCompleter(typeof(AssemblyNameArgumentCompleter))]
         public string Name { get; set; }
 
         /// <summary>

--- a/src/ClassExplorer/NamespaceArgumentCompleter.cs
+++ b/src/ClassExplorer/NamespaceArgumentCompleter.cs
@@ -1,0 +1,41 @@
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+using ClassExplorer.Commands;
+
+namespace ClassExplorer
+{
+    /// <summary>
+    /// Provides argument completion for namespace input parameters.
+    /// </summary>
+    public class NamespaceArgumentCompleter : IArgumentCompleter
+    {
+        /// <summary>
+        /// Called by the PowerShell engine to complete a parameter.
+        /// </summary>
+        /// <param name="commandName">The name of the command.</param>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <param name="wordToComplete">The current parameter value.</param>
+        /// <param name="commandAst">The AST of the command.</param>
+        /// <param name="fakeBoundParameters">A dictionary of currently bound parameters.</param>
+        /// <returns>The result of completion.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters)
+        {
+            return new FindNamespaceCommand() { Name = wordToComplete + "*" }
+                .Invoke<NamespaceInfo>()
+                .Select(
+                    ns => new CompletionResult(
+                        ns.FullName,
+                        ns.FullName,
+                        CompletionResultType.ParameterValue,
+                        ns.FullName));
+        }
+    }
+}

--- a/src/ClassExplorer/NamespaceInfo.cs
+++ b/src/ClassExplorer/NamespaceInfo.cs
@@ -1,0 +1,196 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Reflection;
+using ClassExplorer.Commands;
+
+namespace ClassExplorer
+{
+    /// <summary>
+    /// Provides a representation of a namespace.
+    /// </summary>
+    public class NamespaceInfo : MemberInfo
+    {
+        private static readonly object[] s_emptyArray = new object[0] { };
+
+        private static readonly Lazy<NamespaceCache> s_namespaceCache =
+            new Lazy<NamespaceCache>(() => new NamespaceCache());
+
+        private readonly List<Assembly> _assemblies = new List<Assembly>();
+
+        /// <summary>
+        /// Initializes a new instance of the <see cref="NamespaceInfo" /> class.
+        /// </summary>
+        /// <param name="fullName">The full name of the namespace.</param>
+        /// <param name="assemblies">The assemblies that declare types within this namespace.</param>
+        internal NamespaceInfo(string fullName, IEnumerable<Assembly> assemblies)
+        {
+            if (string.IsNullOrWhiteSpace(fullName)) throw new ArgumentNullException(nameof(fullName));
+            if (assemblies == null || !assemblies.Any()) throw new ArgumentNullException(nameof(assemblies));
+            Name = fullName.Split('.').Last();
+            FullName = fullName;
+            _assemblies.AddRange(assemblies);
+        }
+
+        /// <summary>
+        /// Gets the full name.
+        /// </summary>
+        public string FullName { get; }
+
+        /// <summary>
+        /// Gets the last section of the namespace. For example, the name of the namespace
+        /// System.Management.Automation would be Automation.
+        /// </summary>
+        public override string Name { get; }
+
+        /// <summary>
+        /// Gets the assemblies that declare classes within this namespace.
+        /// </summary>
+        public ReadOnlyCollection<Assembly> Assemblies => _assemblies.AsReadOnly();
+
+        /// <summary>
+        /// Gets the type of member. This is always "Custom".
+        /// </summary>
+        public override MemberTypes MemberType { get; } = MemberTypes.Custom;
+
+        /// <summary>
+        /// Gets the declaring type. This is always <see cref="NamespaceInfo" />.
+        /// </summary>
+        public override Type DeclaringType => typeof(NamespaceInfo);
+
+        /// <summary>
+        /// Gets the reflected type. This is always <see cref="NamespaceInfo" />.
+        /// </summary>
+        public override Type ReflectedType => typeof(NamespaceInfo);
+
+        /// <summary>
+        /// Gets a dictionary of all cached namespaces.
+        /// </summary>
+        internal static Dictionary<string, NamespaceInfo> Namespaces => s_namespaceCache.Value._namespaces;
+
+        /// <summary>
+        /// Gets all cached namespace names.
+        /// </summary>
+        internal static IEnumerable<string> CachedNames => s_namespaceCache.Value._names;
+
+        /// <summary>
+        /// Gets custom attributes for the member. This currently always returns an empty array.
+        /// </summary>
+        /// <param name="inherit">The parameter is not used.</param>
+        /// <returns>An empty array.</returns>
+        public override object[] GetCustomAttributes(bool inherit)
+        {
+            return s_emptyArray;
+        }
+
+        /// <summary>
+        /// Gets custom attributes for the member. This currently always returns an empty array.
+        /// </summary>
+        /// <param name="attributeType">The parameter is not used.</param>
+        /// <param name="inherit">The parameter is not used.</param>
+        /// <returns>An empty array.</returns>
+        public override object[] GetCustomAttributes(Type attributeType, bool inherit)
+        {
+            return s_emptyArray;
+        }
+
+        /// <summary>
+        /// Tests if an attribute is defined for this member. This currently always returns false.
+        /// </summary>
+        /// <param name="attributeType">The parameter is not used.</param>
+        /// <param name="inherit">The parameter is not used.</param>
+        /// <returns>A value indicating whether the attribute is defined.</returns>
+        public override bool IsDefined(Type attributeType, bool inherit)
+        {
+            return false;
+        }
+
+        /// <summary>
+        /// Returns the full name of the namespace.
+        /// </summary>
+        /// <returns>A string containing the full name of the namespace.</returns>
+        public override string ToString()
+        {
+            return FullName;
+        }
+
+        /// <summary>
+        /// Gets all namespaces in the current AppDomain.
+        /// </summary>
+        /// <returns>A collection of namespaces.</returns>
+        internal static ReadOnlyCollection<NamespaceInfo> GetNamespaces()
+        {
+            return new ReadOnlyCollection<NamespaceInfo>(
+                new List<NamespaceInfo>(Namespaces.Values));
+        }
+
+        /// <summary>
+        /// Adds an assembly to the list of assemblies that declare types within this namespace.
+        /// </summary>
+        /// <param name="assembly">The assembly to add.</param>
+        internal void AddAssembly(Assembly assembly)
+        {
+            if (assembly == null) throw new ArgumentNullException(nameof(assembly));
+            _assemblies.Add(assembly);
+        }
+
+        private class NamespaceCache
+        {
+            internal readonly HashSet<string> _names = new HashSet<string>();
+
+            internal readonly Dictionary<string, NamespaceInfo> _namespaces;
+
+            internal NamespaceCache()
+            {
+                _names = new HashSet<string>();
+                _namespaces = LoadNamespaces();
+                foreach (var name in _namespaces.Values)
+                {
+                    _names.Add(name.Name);
+                }
+            }
+
+            private static IEnumerable<NamespaceInfo> GetNamespaces(IEnumerable<Type> types)
+            {
+                return types.GroupBy(type => type.Namespace)
+                    .Where(group => !string.IsNullOrWhiteSpace(group.Key))
+                    .Select(
+                        group => new NamespaceInfo(
+                            group.Key,
+                            group.Select(type => type.Assembly).Distinct()));
+            }
+
+            private Dictionary<string, NamespaceInfo> LoadNamespaces()
+            {
+                AppDomain.CurrentDomain.AssemblyLoad += AppDomain_OnAssemblyLoad;
+                try
+                {
+                    return GetNamespaces(new FindTypeCommand().Invoke<Type>())
+                        .ToDictionary(ns => ns.FullName);
+                }
+                catch (Exception)
+                {
+                    // TODO: Better handling
+                    AppDomain.CurrentDomain.AssemblyLoad -= AppDomain_OnAssemblyLoad;
+                    throw;
+                }
+            }
+
+            private void AppDomain_OnAssemblyLoad(object source, AssemblyLoadEventArgs e)
+            {
+                foreach (var ns in GetNamespaces(e.LoadedAssembly.GetTypes()))
+                {
+                    if (_namespaces.TryGetValue(ns.FullName, out NamespaceInfo existing))
+                    {
+                        existing.AddAssembly(e.LoadedAssembly);
+                        continue;
+                    }
+
+                    _namespaces.Add(ns.FullName, ns);
+                    _names.Add(ns.Name);
+                }
+            }
+        }
+    }
+}

--- a/src/ClassExplorer/NamespaceNameArgumentCompleter.cs
+++ b/src/ClassExplorer/NamespaceNameArgumentCompleter.cs
@@ -1,0 +1,42 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Management.Automation;
+using System.Management.Automation.Language;
+
+namespace ClassExplorer
+{
+    /// <summary>
+    /// Provides argument completion for namespace name input parameters.
+    /// </summary>
+    public class NamespaceNameArgumentCompleter : IArgumentCompleter
+    {
+        /// <summary>
+        /// Called by the PowerShell engine to complete a parameter.
+        /// </summary>
+        /// <param name="commandName">The name of the command.</param>
+        /// <param name="parameterName">The name of the parameter.</param>
+        /// <param name="wordToComplete">The current parameter value.</param>
+        /// <param name="commandAst">The AST of the command.</param>
+        /// <param name="fakeBoundParameters">A dictionary of currently bound parameters.</param>
+        /// <returns>The result of completion.</returns>
+        public IEnumerable<CompletionResult> CompleteArgument(
+            string commandName,
+            string parameterName,
+            string wordToComplete,
+            CommandAst commandAst,
+            IDictionary fakeBoundParameters)
+        {
+            return NamespaceInfo
+                .CachedNames
+                .Where(name => name.StartsWith(wordToComplete, StringComparison.OrdinalIgnoreCase))
+                .Select(
+                    name => new CompletionResult(
+                        name,
+                        name,
+                        CompletionResultType.ParameterValue,
+                        name));
+        }
+    }
+}

--- a/test/Completion.Tests.ps1
+++ b/test/Completion.Tests.ps1
@@ -11,21 +11,31 @@ function Complete {
             CompleteInput(
                 $Expression,
                 $Expression.Length,
-                $null)
+                $null).
+                CompletionMatches
     }
 }
 
 Describe 'Completion tests' {
     It 'can complete type name' {
-        $results = complete 'Find-Type -Name Toke'
-
-        $results.CompletionMatches | ShouldAll { $_.CompletionText.StartsWith('Token') }
-        $results.CompletionMatches | Should -Not -BeNullOrEmpty
+        Complete 'Find-Type -Name Toke' | Should -All { $_.CompletionText.StartsWith('Token') }
     }
-    It 'can complete type full names' {
-        $results = complete 'Find-Member -ReturnType Ast'
 
-        $results.CompletionMatches |
-            ShouldAny { $_.CompletionText -eq 'System.Management.Automation.Language.Ast' }
+    It 'can complete type full names' {
+        Complete 'Find-Member -ReturnType Ast' | Should -All { $_.CompletionText -match '\.Ast' }
+    }
+
+    It 'can complete namespace names' {
+        Complete 'Find-Namespace Autom' | Should -HaveProperty CompletionText -WithValue Automation
+    }
+
+    It 'can complete namespaces' {
+        Complete 'Find-Namespace -FullName Autom' |
+            Should -HaveProperty CompletionText -WithValue System.Management.Automation
+    }
+
+    It 'can complete assembly names' {
+        Complete 'Get-Assembly System.Management.Autom' |
+            Should -HaveProperty CompletionText -WithValue System.Management.Automation
     }
 }

--- a/test/Find-Member.Tests.ps1
+++ b/test/Find-Member.Tests.ps1
@@ -14,14 +14,14 @@ Describe 'Find-Member cmdlet tests' {
             $results = get-item . | Find-Member
 
             $results | Should -Not -BeNullOrEmpty
-            $results | ShouldAll { $_.ReflectedType -eq [System.IO.DirectoryInfo] }
+            $results | Should -All { $_.ReflectedType -eq [System.IO.DirectoryInfo] }
         }
 
         It 'filters passed members' {
             $source = [powershell] | Find-Member -Force
             $results = $source | Find-Member -Static
 
-            $results | ShouldAll { $_ -in $source }
+            $results | Should -All { $_ -in $source }
             $results.Count | Should -Not -Be $source.Count
         }
     }
@@ -35,10 +35,10 @@ Describe 'Find-Member cmdlet tests' {
         $result = $ExecutionContext.SessionState | Find-Member -Force
 
         # A nonpublic member is present
-        $result | ShouldAny { $_.Name -eq 'Internal' -and 'Property' -eq $_.MemberType }
+        $result | Should -Any { $_.Name -eq 'Internal' -and 'Property' -eq $_.MemberType }
 
         # A public member is still present
-        $result | ShouldAny { $_.Name -eq 'Module' -and 'Property' -eq $_.MemberType }
+        $result | Should -Any { $_.Name -eq 'Module' -and 'Property' -eq $_.MemberType }
     }
 
     It 'matches with FilterScript' {
@@ -51,39 +51,39 @@ Describe 'Find-Member cmdlet tests' {
     }
 
     It 'matches name with wildcards' {
-        [powershell] | Find-Member Creat* | ShouldAny { $_.Name -eq 'Create' }
+        [powershell] | Find-Member Creat* | Should -Any { $_.Name -eq 'Create' }
     }
 
     It 'matches name with regex' {
         $result = [runspacefactory] | Find-Member Create.*Runspace -RegularExpression
 
-        $result | ShouldAny { $_.Name -eq 'CreateRunspace' }
-        $result | ShouldAny { $_.Name -eq 'CreateOutOfProcessRunspace' }
+        $result | Should -Any { $_.Name -eq 'CreateRunspace' }
+        $result | Should -Any { $_.Name -eq 'CreateOutOfProcessRunspace' }
     }
 
     It 'matches parameter type' {
         [System.Management.Automation.Language.Parser] |
             Find-Member -ParameterType System.Management.Automation.Language.Token |
-            ShouldAny { $_.Name -eq 'ParseInput' }
+            Should -Any { $_.Name -eq 'ParseInput' }
     }
 
     It 'matches return type' {
         [powershell] |
             Find-Member -ReturnType PowerShell |
-            ShouldAny { $_.Name -eq 'Create' }
+            Should -Any { $_.Name -eq 'Create' }
     }
 
     It 'return type matches constructors' {
         [System.Collections.Generic.List[string]] |
             Find-Member -ReturnType System.Collections.Generic.List[string] |
-            ShouldAny { 'Constructor' -eq $_.MemberType }
+            Should -Any { 'Constructor' -eq $_.MemberType }
     }
 
     It 'unwraps target types with elements' {
         $result = [System.Management.Automation.Language.Parser] |
             Find-Member -ParameterType System.Management.Automation.Language.Token
 
-        $result | ShouldAny {
+        $result | Should -Any {
             ($parameters = $_.GetParameters()) -and
             $parameters[1].ParameterType.IsByRef -and
             $parameters[1].ParameterType.GetElementType().IsArray
@@ -101,33 +101,33 @@ Describe 'Find-Member cmdlet tests' {
     It 'filters to virtual members' {
         $results = [runspace] | Find-Member -Virtual
 
-        $results | ShouldAll { $_.IsVirtual }
-        $results | ShouldAny { $_.Name -eq 'CreateNestedPipeline' }
-        $results | ShouldAny { $_.Name -eq 'GetHashCode' }
+        $results | Should -All { $_.IsVirtual }
+        $results | Should -Any { $_.Name -eq 'CreateNestedPipeline' }
+        $results | Should -Any { $_.Name -eq 'GetHashCode' }
     }
 
     It 'filters to abstract' {
         $results = [runspace] | Find-Member -Abstract
 
-        $results | ShouldAll { $_.IsAbstract }
-        $results | ShouldAny { $_.Name -eq 'Open' }
-        $results | ShouldAll { $_.Name -ne 'GetHashCode' }
+        $results | Should -All { $_.IsAbstract }
+        $results | Should -Any { $_.Name -eq 'Open' }
+        $results | Should -All { $_.Name -ne 'GetHashCode' }
     }
 
     It 'filters to instance' {
         $results = [powershell] | Find-Member -Instance
 
-        $results | ShouldAll { -not $_.IsStatic -and -not $_.GetMethod.IsStatic }
-        $results | ShouldAll { $_.Name -ne 'Create' }
-        $results | ShouldAny { $_.Name -eq 'AddScript' }
+        $results | Should -All -Not { $_.IsStatic -or $_.GetMethod.IsStatic }
+        $results | Should -All -Not { $_.Name -eq 'Create' }
+        $results | Should -Any { $_.Name -eq 'AddScript' }
     }
 
     It 'filters to static' {
         $results = [powershell] | Find-Member -Static
 
-        $results | ShouldAll { $_.IsStatic -or $_.GetMethod.IsStatic }
-        $results | ShouldAll { $_.Name -ne 'AddScript' }
-        $results | ShouldAny { $_.Name -eq 'Create' }
+        $results | Should -All { $_.IsStatic -or $_.GetMethod.IsStatic }
+        $results | Should -All { $_.Name -ne 'AddScript' }
+        $results | Should -Any { $_.Name -eq 'Create' }
     }
 
     It 'gets members for passed objects only once per type' {

--- a/test/Find-Namespace.Tests.ps1
+++ b/test/Find-Namespace.Tests.ps1
@@ -1,0 +1,46 @@
+$moduleName = 'ClassExplorer'
+$manifestPath = "$PSScriptRoot\..\Release\$moduleName"
+
+Import-Module $manifestPath
+Import-Module $PSScriptRoot\shared.psm1
+
+Describe 'Find-Namespace tests' {
+    Describe 'input from the pipeline' {
+        It 'gets a namespace from an object' {
+            [System.IO.FileInfo]::new('test') |
+                Find-Namespace |
+                Should -HaveProperty Name -WithValue IO
+        }
+
+        It 'gets namespaces from an assembly' {
+            Get-Assembly System.Management.Automation |
+                Find-Namespace |
+                Should -Any { $_.Name -eq 'Runspaces' }
+        }
+
+        It 'gets namespaces from a type' {
+            [type] | Find-Namespace | Should -HaveProperty Name -WithValue System
+        }
+
+        It 'gets namespaces from a member' {
+            [powershell] |
+                Find-Member Streams |
+                Find-Namespace |
+                Should -HaveProperty Name -WithValue Automation
+        }
+    }
+
+    Describe 'general functionality' {
+        It 'gets all namespaces' {
+            $results = Find-Namespace
+            $results.Count | Should -BeGreaterThan 100
+        }
+
+
+        It 'can negate filters' {
+            Find-Namespace |
+                Find-Namespace -FullName 'Microsoft|System' -Regex -Not |
+                Should -All -Not { $_.FullName -match 'Microsoft|System' }
+        }
+    }
+}

--- a/test/Find-Type.Tests.ps1
+++ b/test/Find-Type.Tests.ps1
@@ -12,7 +12,7 @@ Describe 'Find-Type tests' {
         It 'gets types from passed assemblies' {
             $results = Get-Assembly ClassExplorer | Find-Type
 
-            $results | ShouldAll { $_.Assembly.GetName().Name -eq 'ClassExplorer' }
+            $results | Should -All { $_.Assembly.GetName().Name -eq 'ClassExplorer' }
         }
         It 'gets the type of any other object passed' {
             Get-Item . | Find-Type | Should -Be ([System.IO.DirectoryInfo])
@@ -30,7 +30,7 @@ Describe 'Find-Type tests' {
 
         It 'accepts both a name and a script block as named parameters in the same command' {
             Find-Type -Name Runspace* -FilterScript { $_.IsAbstract } |
-                ShouldAny { $_ -eq [runspace] }
+                Should -Any { $_ -eq [runspace] }
         }
 
         It 'accepts namespace at position 1' {
@@ -50,45 +50,56 @@ Describe 'Find-Type tests' {
         $result.Count | Should -Be 1
         $result | Should -Be ([powershell])
     }
+
     It 'matches by name' {
         Find-Type RunspaceMode | Should -Be ([System.Management.Automation.RunspaceMode])
     }
+
     It 'matches by namespace' {
-        Find-Type -Namespace System.Timers | ShouldAll { $_.Namespace -eq 'System.Timers' }
+        Find-Type -Namespace System.Timers | Should -All { $_.Namespace -eq 'System.Timers' }
     }
+
     It 'matches by full name' {
         Find-Type -FullName System.Management.Automation.ProxyCommand |
             Should -Be ([System.Management.Automation.ProxyCommand])
     }
+
     It 'matches by name with regex' {
         Find-Type "Runspace(Factory|ConnectionInfo)" -RegularExpression |
             Should -Be ([runspacefactory], [System.Management.Automation.Runspaces.RunspaceConnectionInfo])
     }
+
     It 'matches by namespace with regex' {
         Find-Type MethodAttributes -Namespace 'System\.(?!Reflection).+' -RegularExpression |
             Should -Be ([System.Management.Automation.Language.MethodAttributes])
     }
+
     It 'matches by full name with regex' {
         Find-Type -FullName 'System\.(?!Threading)\w+\.Timer$' -RegularExpression |
             Should -Be ([System.Timers.Timer])
     }
+
     It 'matches by base class' {
         $results = Find-Type -InheritsType System.Management.Automation.Language.Ast
 
-        $results | ShouldAll { $_.IsSubclassOf([System.Management.Automation.Language.Ast]) }
+        $results | Should -All { $_.IsSubclassOf([System.Management.Automation.Language.Ast]) }
         $results | Should -Not -BeNullOrEmpty
     }
+
     It 'matches by interface' {
         Find-Type -ImplementsInterface System.Collections.IList |
-            ShouldAll { $_.ImplementedInterfaces -contains [System.Collections.IList] }
+            Should -All { $_.ImplementedInterfaces -contains [System.Collections.IList] }
     }
+
     It 'filters to only interfaces' {
-        Find-Type -Interface | ShouldAll { $_.IsInterface }
+        Find-Type -Interface | Should -All { $_.IsInterface }
     }
+
     It 'filters to only abstract' {
-        Find-Type -Abstract | ShouldAll { $_.IsAbstract }
+        Find-Type -Abstract | Should -All { $_.IsAbstract }
     }
+
     It 'filters to only value types' {
-        Find-Type -ValueType | ShouldAll { $_.IsValueType }
+        Find-Type -ValueType | Should -All { $_.IsValueType }
     }
 }

--- a/test/Get-Assembly.Tests.ps1
+++ b/test/Get-Assembly.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Get-Assembly Tests' {
     It 'can get assemblies' {
         $results = Get-Assembly
 
-        $results | ShouldAny { $_.GetName().Name -eq 'ClassExplorer' }
+        $results | Should -Any { $_.GetName().Name -eq 'ClassExplorer' }
         $results.Count | Should -BeGreaterThan 5
     }
     It 'can get a specific assembly' {
@@ -18,7 +18,7 @@ Describe 'Get-Assembly Tests' {
     }
     It 'matches assemblies using wildcards' {
         $results = Get-Assembly *PowerShell*
-        $results | ShouldAll { $_.GetName().Name -match 'PowerShell' }
+        $results | Should -All { $_.GetName().Name -match 'PowerShell' }
         $results.Count | Should -BeGreaterThan 1
     }
 }

--- a/test/Get-Parameter.Tests.ps1
+++ b/test/Get-Parameter.Tests.ps1
@@ -8,7 +8,7 @@ Describe 'Get-Parameter tests' {
     It 'gets parameters' {
         $results = [powershell] | Find-Member -MemberType Method | Get-Parameter
 
-        $results | ShouldAny { $_.Name -eq 'asyncResult' }
+        $results | Should -Any { $_.Name -eq 'asyncResult' }
     }
 
     It 'returns nothing without input' {

--- a/test/shared.psm1
+++ b/test/shared.psm1
@@ -1,44 +1,173 @@
-function ShouldAny {
+function BeTrueForAll {
+    [CmdletBinding()]
     param(
-        [scriptblock] $Assertion,
-
-        [Parameter(ValueFromPipeline)]
-        [psobject]
-        $InputObject
+        $ActualValue,
+        [scriptblock] $TestScript,
+        [switch] $Negate
     )
-    begin { $list = [System.Collections.Generic.List[psobject]]::new() }
-    process { $list.Add($InputObject) }
     end {
+        foreach ($value in $ActualValue) {
+            $variables = [System.Collections.Generic.List[psvariable]](
+                [psvariable]::new('_', $value))
 
-        $results = foreach ($item in $list) {
-            [System.Management.Automation.LanguagePrimitives]::IsTrue(
-                $Assertion.InvokeWithContext(
-                    $null,
-                    [psvariable]::new('_', $item) -as [System.Collections.Generic.List[psvariable]],
-                    $item))
+            $succeeded = $TestScript.InvokeWithContext(
+                <# functionsToDefine: #> @{},
+                <# variablesToDefine: #> $variables,
+                <# args:              #> $value)
+
+            if ($Negate.IsPresent) {
+                $succeeded = -not $succeeded
+            }
+
+            if (-not $succeeded) {
+                break
+            }
         }
-        $results -contains $true | Should Be $true
+
+        if ($Negate.IsPresent) {
+            $failureMessage =
+                'Expected: All values to fail the evaluation script, ' +
+                'but value "{0}" returned true.' -f $value
+        } else {
+            $failureMessage =
+                'Expected: All values to pass the evaluation script, ' +
+                'but value "{0}" returned false.' -f $value
+        }
+
+        [PSCustomObject]@{
+            Succeeded = $succeeded
+            FailureMessage = $failureMessage
+        }
     }
 }
-function ShouldAll {
+
+function BeTrueForAny {
+    [CmdletBinding()]
     param(
-        [scriptblock] $Assertion,
-
-        [Parameter(ValueFromPipeline)]
-        [psobject]
-        $InputObject
+        $ActualValue,
+        [scriptblock] $TestScript,
+        [switch] $Negate
     )
-    begin { $list = [System.Collections.Generic.List[psobject]]::new() }
-    process { $list.Add($InputObject) }
     end {
+        $succeeded = $false
+        foreach ($value in $ActualValue) {
+            $variables = [System.Collections.Generic.List[psvariable]](
+                [psvariable]::new('_', $value))
 
-        $results = foreach ($item in $list) {
-            [System.Management.Automation.LanguagePrimitives]::IsTrue(
-                $Assertion.InvokeWithContext(
-                    $null,
-                    [psvariable]::new('_', $item) -as [System.Collections.Generic.List[psvariable]],
-                    $item))
+            $succeeded = $TestScript.InvokeWithContext(
+                <# functionsToDefine: #> @{},
+                <# variablesToDefine: #> $variables,
+                <# args:              #> $value)
+
+            if ($Negate.IsPresent) {
+                $succeeded = -not $succeeded
+            }
+
+            if ($succeeded) {
+                break
+            }
         }
-        $results -contains $false | Should Be $false
+
+        if (-not $succeeded) {
+            if ($Negate.IsPresent) {
+                $failureMessage =
+                    'Expected: Any value to fail the evaluation script, ' +
+                    'but no value returned false. (ActualValue: {0})' -f ($ActualValue -join ', ')
+            } else {
+                $failureMessage =
+                    'Expected: Any value to pass the evaluation script, ' +
+                    'but no value returned true. (ActualValue: {0})' -f ($ActualValue -join ', ')
+            }
+        }
+
+        [PSCustomObject]@{
+            Succeeded = $succeeded
+            FailureMessage = $failureMessage
+        }
     }
 }
+
+function HaveProperty {
+    [CmdletBinding()]
+    param(
+        $ActualValue,
+        [string] $PropertyName,
+        $WithValue,
+        [switch] $Negate
+    )
+    end {
+        $shouldTestValue = $PSBoundParameters.ContainsKey('WithValue')
+        if ($null -eq $ActualValue) {
+            if ($shouldTestValue) {
+                if ($Negate.IsPresent) {
+                    $failureMessage = 'Expected: value "{0}" to contain the property "{1}" where the value was not "{2}" but the input object was null.' -f $ActualValue, $PropertyName, $WithValue
+                } else {
+                    $failureMessage = 'Expected: value "{0}" to contain the property "{1}" where the value was "{2}" but the input object was null.' -f $ActualValue, $PropertyName, $WithValue
+                }
+            } else {
+                if ($Negate.IsPresent) {
+                    $failureMessage = 'Expected: value "{0}" to not contain the property "{1}" but the input object was null.' -f $ActualValue, $PropertyName
+                } else {
+                    $failureMessage = 'Expected: value "{0}" to contain the property "{1}" but the input object was null.' -f $ActualValue, $PropertyName
+                }
+            }
+
+            return [PSCustomObject]@{
+                Succeeded = $false
+                FailureMessage = $failureMessage
+            }
+        }
+
+        $property = $ActualValue.psobject.Properties[$PropertyName]
+        $hasProperty = [bool]$property
+        if (-not $shouldTestValue) {
+            $succeeded = $hasProperty
+            if ($Negate.IsPresent) {
+                $succeeded = -not $succeeded
+            }
+
+            if (-not $succeeded) {
+                if ($Negate.IsPresent) {
+                    $failureMessage = 'Expected: value "{0}" to not contain the property "{1}" but it did.' -f $ActualValue, $PropertyName
+                } else {
+                    $failureMessage = 'Expected: value "{0}" to contain the property "{1}" but it did not.' -f $ActualValue, $PropertyName
+                }
+            }
+
+            return [PSCustomObject]@{
+                Succeeded = $succeeded
+                FailureMessage = $failureMessage
+            }
+        }
+
+        if (-not $hasProperty) {
+            if ($Negate.IsPresent) {
+                $failureMessage = 'Expected: value "{0}" to contain the property "{1}" where the value was not "{2}" but the property did not exist.' -f $ActualValue, $PropertyName, $WithValue
+            } else {
+                $failureMessage = 'Expected: value "{0}" to contain the property "{1}" where the value was "{2}" but the property did not exist.' -f $ActualValue, $PropertyName, $WithValue
+            }
+
+            return [PSCustomObject]@{
+                Succeeded = $false
+                FailureMessage = $failureMessage
+            }
+        }
+
+        $succeeded = $WithValue -eq $property.Value
+        if ($Negate.IsPresent) {
+            $succeeded = -not $succeeded
+            $failureMessage = 'Expected: value "{0}" to contain the property "{1}" where the value was not "{2}" but it was.' -f $ActualValue, $PropertyName, $WithValue
+        } else {
+            $failureMessage = 'Expected: value "{0}" to contain the property "{1}" where the value was not "{2}" but the actual value was "{3}".' -f $ActualValue, $PropertyName, $WithValue, $property.Value
+        }
+
+        [PSCustomObject]@{
+            Succeeded = $succeeded
+            FailureMessage = $failureMessage
+        }
+    }
+}
+
+Add-AssertionOperator -Name BeTrueForAll -Test $function:BeTrueForAll -Alias All -SupportsArrayInput
+Add-AssertionOperator -Name BeTrueForAny -Test $function:BeTrueForAny -Alias Any -SupportsArrayInput
+Add-AssertionOperator -Name HaveProperty -Test $function:HaveProperty

--- a/tools/AssertRequiredModule.ps1
+++ b/tools/AssertRequiredModule.ps1
@@ -1,0 +1,27 @@
+[CmdletBinding()]
+param(
+    [string] $Name,
+
+    [version] $RequiredVersion,
+
+    [switch] $Force
+)
+end {
+    if (Get-Module $Name) {
+        Remove-Module $Name -Force
+    }
+
+    $importModuleSplat = @{
+        RequiredVersion = $RequiredVersion
+        Name = $Name
+        ErrorAction = 'Stop'
+    }
+
+    # TODO: Install required versions into the tools folder
+    try {
+        Import-Module @importModuleSplat -Force
+    } catch [System.IO.FileNotFoundException] {
+        Install-Module @importModuleSplat -Force:$Force.IsPresent -Scope CurrentUser
+        Import-Module @importModuleSplat -Force
+    }
+}

--- a/tools/CreateFormatDefinitions.ps1
+++ b/tools/CreateFormatDefinitions.ps1
@@ -11,6 +11,21 @@ param(
 end {
     $CLASSEXPLORER_FORMAT_PS1XML = {
         [ExtendedTypeDefinition]::new(
+            'ClassExplorer.NamespaceInfo',
+            [FormatViewDefinition]::new(
+                'ClassExplorer.NamespaceInfo',
+                [TableControl]::Create().
+                    AddHeader('Left', 20).
+                    AddHeader('Left', 40).
+                    AddHeader('Left', $null, 'Assemblies').
+                    StartRowDefinition().
+                        AddPropertyColumn('Name').
+                        AddPropertyColumn('FullName').
+                        AddScriptBlockColumn('$_.Assemblies.GetName().Name -join ", "').
+                    EndRowDefinition().
+                EndTable()) -as [FormatViewDefinition[]])
+
+        [ExtendedTypeDefinition]::new(
             'System.Reflection.MemberInfo',
             [FormatViewDefinition]::new(
                 'System.Reflection.MemberInfo',

--- a/tools/GetDotNet.ps1
+++ b/tools/GetDotNet.ps1
@@ -1,6 +1,6 @@
 [CmdletBinding()]
 param(
-    [string] $Version = '2.0.0',
+    [string] $Version = '2.1.2',
 
     [switch] $Unix
 )

--- a/tools/InvokeCircleCI.ps1
+++ b/tools/InvokeCircleCI.ps1
@@ -1,19 +1,12 @@
-Install-Module Pester -RequiredVersion 4.0.6 -Scope CurrentUser -Force
-Install-Module InvokeBuild -RequiredVersion 3.2.1 -Scope CurrentUser -Force
-Install-Module platyPS -RequiredVersion 0.8.1 -Scope CurrentUser -Force
-
-Import-Module Pester 2> $null
-Import-Module InvokeBuild, platyPS
-
 $env:DOTNET_SKIP_FIRST_TIME_EXPERIENCE = 'true'
 $env:DOTNET_CLI_TELEMETRY_OPTOUT = 'true'
 
+& "$PSScriptRoot/../build.ps1" -Force
 Invoke-Build -File $PSScriptRoot/../ClassExplorer.build.ps1 -Configuration Release -Task Prerelease
 
 $resultsFile = "$PSScriptRoot/../testresults/pester.xml"
 
 $passed = (Test-Path $resultsFile) -and 0 -eq ([int]([xml](Get-Content $resultsFile -Raw)).'test-results'.failures)
-
 
 if (-not $passed) {
     $Error | Format-List * -Force


### PR DESCRIPTION
# Version 1.1.0

## Find-Namespace Cmdlet

Added the `Find-Namespace` cmdlet for searching the AppDomain for specific namespaces.  This is
paticularly useful when exploring a new assembly to get a quick idea what's available. The namespace
objects returned from this cmdlet can be piped into `Find-Type` or `Find-Member`.

## More argument completion

Namespace parameters for `Find-Namespace` and `Find-Type` now have tab completion. The `Name` parameter
for `Get-Assembly` will now also complete assembly names.

## Not parameter

The cmdlets `Find-Namespace`, `Find-Type`, and `Find-Member` now have a `Not` parameter to negate the
search criteria. This makes chaining the commands to filter results a lot easier. Here's a basic example.

```powershell
Find-Namespace Automation | Find-Member -Static | Find-Member -MemberType Field -Not
```

## Fixes

- The `Find-*` cmdlets no longer return all matches in the AppDomain if passed null pipeline input

- Added support for explicitly specifying the `InputObject` parameter from pipeline position 0

- `Find-Type` no longer throws when the `Namespace` parameter is specified with the `RegularExpression`
  switch parameter

- Various build and test fixes