### PR TITLE
Add `-RecurseNestedType` param

### DIFF
--- a/docs/en-US/Find-Member.md
+++ b/docs/en-US/Find-Member.md
@@ -16,13 +16,13 @@ Find properties, methods, fields, etc that fit specific criteria.
 
 ```powershell
 
-Find-Member [[-FilterScript] <scriptblock>] [-ParameterType <ScriptBlockStringOrType>] [-GenericParameter <ScriptBlockStringOrType>] [-ParameterCount <RangeExpression[]>] [-GenericParameterCount <RangeExpression[]>] [-ReturnType <ScriptBlockStringOrType>] [-IncludeSpecialName] [-Decoration <ScriptBlockStringOrType>] [-MemberType <MemberTypes>] [-Static] [-Instance] [-Abstract] [-Virtual] [-Declared] [-IncludeObject] [-Name <string>] [-Force] [-RegularExpression] [-InputObject <psobject>] [-Not] [-ResolutionMap <hashtable>] [-AccessView <AccessView>] [<CommonParameters>]
+Find-Member [[-FilterScript] <scriptblock>] [-ParameterType <ScriptBlockStringOrType>] [-GenericParameter <ScriptBlockStringOrType>] [-ParameterCount <RangeExpression[]>] [-GenericParameterCount <RangeExpression[]>] [-ReturnType <ScriptBlockStringOrType>] [-IncludeSpecialName] [-Decoration <ScriptBlockStringOrType>] [-MemberType <MemberTypes>] [-Static] [-Instance] [-Abstract] [-Virtual] [-Declared] [-IncludeObject] [-RecurseNestedType] [-Name <string>] [-Force] [-RegularExpression] [-InputObject <psobject>] [-Not] [-ResolutionMap <hashtable>] [-AccessView <AccessView>] [<CommonParameters>]
 ```
 
 ### ByName
 
 ```powershell
-Find-Member [[-Name] <string>] [-ParameterType <ScriptBlockStringOrType>] [-GenericParameter <ScriptBlockStringOrType>] [-ParameterCount <RangeExpression[]>] [-GenericParameterCount <RangeExpression[]>] [-ReturnType <ScriptBlockStringOrType>] [-IncludeSpecialName] [-Decoration <ScriptBlockStringOrType>] [-MemberType <MemberTypes>] [-Static] [-Instance] [-Abstract] [-Virtual] [-Declared] [-IncludeObject] [-FilterScript <scriptblock>] [-Force] [-RegularExpression] [-InputObject <psobject>] [-Not] [-ResolutionMap <hashtable>] [-AccessView <AccessView>] [<CommonParameters>]
+Find-Member [[-Name] <string>] [-ParameterType <ScriptBlockStringOrType>] [-GenericParameter <ScriptBlockStringOrType>] [-ParameterCount <RangeExpression[]>] [-GenericParameterCount <RangeExpression[]>] [-ReturnType <ScriptBlockStringOrType>] [-IncludeSpecialName] [-Decoration <ScriptBlockStringOrType>] [-MemberType <MemberTypes>] [-Static] [-Instance] [-Abstract] [-Virtual] [-Declared] [-IncludeObject] [-RecurseNestedType] [-FilterScript <scriptblock>] [-Force] [-RegularExpression] [-InputObject <psobject>] [-Not] [-ResolutionMap <hashtable>] [-AccessView <AccessView>] [<CommonParameters>]
 ```
 
 ## DESCRIPTION
@@ -578,6 +578,24 @@ Specifying this parameter will include these members in the results.
 Type: SwitchParameter
 Parameter Sets: (All)
 Aliases: io
+
+Required: False
+Position: Named
+Default value: None
+Accept pipeline input: False
+Accept wildcard characters: False
+```
+
+### -RecurseNestedType
+
+Nested types will by default be treated as members other members. When piping a nested
+type to this command, if you want to retrieve the members of the nested type
+can specify this parameter.
+
+```yaml
+Type: SwitchParameter
+Parameter Sets: (All)
+Aliases: r
 
 Required: False
 Position: Named

--- a/src/ClassExplorer/Commands/FindMemberCommand.cs
+++ b/src/ClassExplorer/Commands/FindMemberCommand.cs
@@ -173,6 +173,14 @@ namespace ClassExplorer.Commands
             set => _options.IncludeObject = value;
         }
 
+        [Parameter]
+        [Alias("r")]
+        public SwitchParameter RecurseNestedType
+        {
+            get => _options.RecurseNestedType;
+            set => _options.RecurseNestedType = value;
+        }
+
         private MemberSearch<PipelineEmitter<MemberInfo>> _search = null!;
 
         private protected override void OnNoInput()

--- a/src/ClassExplorer/MemberSearch.cs
+++ b/src/ClassExplorer/MemberSearch.cs
@@ -46,7 +46,7 @@ internal sealed class MemberSearch<TCallback> : ReflectionSearch<MemberInfo, TCa
 
     public override void SearchSingleObject(PSObject pso)
     {
-        if (pso.BaseObject is Type type)
+        if (pso.BaseObject is Type type && (_options.RecurseNestedType || !type.IsNested))
         {
             SearchSingleType(type);
             return;

--- a/src/ClassExplorer/MemberSearchOptions.cs
+++ b/src/ClassExplorer/MemberSearchOptions.cs
@@ -31,4 +31,6 @@ internal class MemberSearchOptions : ReflectionSearchOptions
     public bool Declared { get; set; }
 
     public bool IncludeObject { get; set; }
+
+    public bool RecurseNestedType { get; set; }
 }

--- a/test/Signatures.Tests.ps1
+++ b/test/Signatures.Tests.ps1
@@ -278,15 +278,15 @@ Describe 'Type signatures' {
             }'
 
         $type.GetNestedTypes() |
-            Find-Member -ParameterType { [T] } |
+            Find-Member -RecurseNestedType -ParameterType { [T] } |
             Should -BeTheseMembers First, Second
 
         $type.GetNestedTypes() |
-            Find-Member -ParameterType { [TT] } |
+            Find-Member -RecurseNestedType -ParameterType { [TT] } |
             Should -BeTheseMembers First
 
         $type.GetNestedTypes() |
-            Find-Member -ParameterType { [TM] } |
+            Find-Member -RecurseNestedType -ParameterType { [TM] } |
             Should -BeTheseMembers Second
     }
 


### PR DESCRIPTION
A lot of queries were getting a little harder with automatically
recursing nested types. So you could do something like:

```powershell
Find-Type -Not -Base delegate | Find-Member | Find-Member
```

And end up with a bunch of members from nested delegates. This also lets
you filter nested types easier. Basically we are just actually treating
nested types like other members unless you specifically request
otherwise.