### PR TITLE
Add `-Signature` parameter to `Find-Member`

### DIFF
--- a/src/ClassExplorer/Commands/FindMemberCommand.cs
+++ b/src/ClassExplorer/Commands/FindMemberCommand.cs
@@ -181,6 +181,10 @@ namespace ClassExplorer.Commands
             set => _options.Extension = value;
         }
 
+        [Parameter]
+        [Alias("sig")]
+        public ScriptBlockStringOrType? Signature { get; set; }
+
         private MemberSearch<PipelineEmitter<MemberInfo>> _search = null!;
 
         private protected override void OnNoInput()
@@ -212,6 +216,7 @@ namespace ClassExplorer.Commands
             _options.ResolutionMap = resolutionMap;
             _options.AccessView = AccessView;
             _options.Decoration = Decoration;
+            _options.Signature = Signature;
             _search = Search.Members(_options, new PipelineEmitter<MemberInfo>(this));
         }
     }

--- a/src/ClassExplorer/Commands/FindTypeCommand.cs
+++ b/src/ClassExplorer/Commands/FindTypeCommand.cs
@@ -153,24 +153,24 @@ namespace ClassExplorer.Commands
             Dictionary<string, ScriptBlockStringOrType>? resolutionMap = InitializeResolutionMap();
 
             var parser = new SignatureParser(resolutionMap);
-            var signatures = ImmutableArray.CreateBuilder<ITypeSignature>();
-            ITypeSignature? signature = null;
+            var signatures = ImmutableArray.CreateBuilder<ISignature>();
+            ISignature? signature = null;
             if (Signature is not null)
             {
-                signature = Signature.Resolve(parser);
+                signature = Signature.ResolveType(parser);
                 signatures.Add(signature);
             }
 
             if (InheritsType is not null)
             {
-                ITypeSignature inheritsTypeSignature = InheritsType.Resolve(parser, excludeSelf: true);
+                ISignature inheritsTypeSignature = InheritsType.ResolveType(parser, excludeSelf: true);
                 signatures.Add(inheritsTypeSignature);
                 signature ??= inheritsTypeSignature;
             }
 
             if (ImplementsInterface is not null)
             {
-                ITypeSignature implementsSignature = ImplementsInterface.Resolve(parser, excludeSelf: true);
+                ISignature implementsSignature = ImplementsInterface.ResolveType(parser, excludeSelf: true);
                 signatures.Add(implementsSignature);
                 signature ??= implementsSignature;
             }

--- a/src/ClassExplorer/MemberSearch.cs
+++ b/src/ClassExplorer/MemberSearch.cs
@@ -268,21 +268,21 @@ internal sealed class MemberSearch<TCallback> : ReflectionSearch<MemberInfo, TCa
         if (_options.GenericParameter is not null)
         {
             filters.AddFilter(
-                new GenericParameterTypeSignature(_options.GenericParameter.Resolve(parser)),
+                new GenericParameterTypeSignature(_options.GenericParameter.ResolveType(parser)),
                 static (member, signature) => signature.IsMatch(member));
         }
 
         if (_options.ParameterType is not null)
         {
             filters.AddFilter(
-                new ParameterTypeSignature(_options.ParameterType.Resolve(parser)),
+                new ParameterTypeSignature(_options.ParameterType.ResolveType(parser)),
                 static (member, signature) => signature.IsMatch(member));
         }
 
         if (_options.ReturnType is not null)
         {
             filters.AddFilter(
-                new ReturnTypeSignature(_options.ReturnType.Resolve(parser)),
+                new ReturnTypeSignature(_options.ReturnType.ResolveType(parser)),
                 static (member, signature) => signature.IsMatch(member));
         }
 
@@ -293,6 +293,13 @@ internal sealed class MemberSearch<TCallback> : ReflectionSearch<MemberInfo, TCa
                     SignatureParser.ResolveAttributeTypeName(
                         _options.Decoration,
                         _options.ResolutionMap)),
+                static (member, signature) => signature.IsMatch(member));
+        }
+
+        if (_options.Signature is not null)
+        {
+            filters.AddFilter(
+                (IMemberSignature)_options.Signature.Resolve(parser, SignatureKind.Member),
                 static (member, signature) => signature.IsMatch(member));
         }
     }

--- a/src/ClassExplorer/MemberSearchOptions.cs
+++ b/src/ClassExplorer/MemberSearchOptions.cs
@@ -33,4 +33,6 @@ internal class MemberSearchOptions : ReflectionSearchOptions
     public bool RecurseNestedType { get; set; }
 
     public bool Extension { get; set; }
+
+    public ScriptBlockStringOrType? Signature { get; set; }
 }

--- a/src/ClassExplorer/ReflectionCache.cs
+++ b/src/ClassExplorer/ReflectionCache.cs
@@ -1,0 +1,67 @@
+using System;
+using System.Linq.Expressions;
+using System.Management.Automation;
+using System.Reflection;
+
+namespace ClassExplorer;
+
+internal static class ReflectionCache
+{
+    private static readonly Type? ExecutionContextType;
+
+    private static readonly MethodInfo? GetExecutionContextFromTLSMethod;
+
+    private static readonly Func<string[]>? GetUsingNamespacesFunc;
+
+    static ReflectionCache()
+    {
+        ExecutionContextType = typeof(PSObject).Assembly.GetType("System.Management.Automation.ExecutionContext");
+        if (ExecutionContextType is null) return;
+
+        GetExecutionContextFromTLSMethod = typeof(PSObject).Assembly.GetType("System.Management.Automation.Runspaces.LocalPipeline")
+            ?.GetMethod("GetExecutionContextFromTLS", BindingFlags.Static | BindingFlags.NonPublic | BindingFlags.Public);
+
+        if (GetExecutionContextFromTLSMethod is null) return;
+
+        GetUsingNamespacesFunc = CreateGetUsingNamespaces();
+    }
+
+    public static string[] GetUsingNamespacesFromTLS()
+    {
+        return GetUsingNamespacesFunc?.Invoke() ?? ["System"];
+    }
+
+    private static Func<string[]>? CreateGetUsingNamespaces()
+    {
+        const BindingFlags flags = BindingFlags.NonPublic | BindingFlags.Public | BindingFlags.Instance;
+
+        if (GetExecutionContextFromTLSMethod is null) return null;
+
+        PropertyInfo? getEngineSessionState = ExecutionContextType?.GetProperty("EngineSessionState", flags);
+        if (getEngineSessionState is null) return null;
+
+        PropertyInfo? currentScope = getEngineSessionState.GetReturnType()?.GetProperty("CurrentScope", flags);
+        if (currentScope is null) return null;
+
+        PropertyInfo? typeRes = currentScope.GetReturnType()?.GetProperty("TypeResolutionState", flags);
+        if (typeRes is null) return null;
+
+        FieldInfo? namespaces = typeRes.GetReturnType()?.GetField("namespaces", flags);
+        if (namespaces is null) return null;
+        if (namespaces.FieldType != typeof(string[])) return null;
+
+        return Expression.Lambda<Func<string[]>>(
+            Expression.Field(
+                Expression.Call(
+                    Expression.Call(
+                        Expression.Call(
+                            Expression.Call(GetExecutionContextFromTLSMethod),
+                            getEngineSessionState.GetGetMethod(nonPublic: true)),
+                        currentScope.GetGetMethod(nonPublic: true)),
+                    typeRes.GetGetMethod(nonPublic: true)),
+                namespaces),
+            "GetUsingNamespacesDynamically",
+            [])
+            .Compile();
+    }
+}

--- a/src/ClassExplorer/SR.resx
+++ b/src/ClassExplorer/SR.resx
@@ -129,6 +129,9 @@
   <data name="DecorationBadArgs" xml:space="preserve">
     <value>The keyword "decoration" requires exactly one generic argument (Example: [decoration[ParameterAttribute]]). See https://seemingly.dev/about-type-signatures or help about_Type_Signatures.</value>
   </data>
+  <data name="SigBadArgs" xml:space="preserve">
+    <value>The keyword "sig" requires at least one generic argument representing the return type (Example: [sig[Arg1, Arg2, void]]). See https://seemingly.dev/about-type-signatures or help about_Type_Signatures.</value>
+  </data>
   <data name="TypeNotFound" xml:space="preserve">
     <value>Unable to find type [{0}].</value>
   </data>

--- a/src/ClassExplorer/SignatureWriter.cs
+++ b/src/ClassExplorer/SignatureWriter.cs
@@ -1066,6 +1066,17 @@ internal class SignatureWriter
         return NewLineNoIndent().NewLine();
     }
 
+    public SignatureWriter WriteMember(MemberInfo member)
+        => member switch
+        {
+            MethodBase m => Member(m),
+            EventInfo m => Member(m),
+            PropertyInfo m => Member(m),
+            FieldInfo m => Member(m),
+            Type m => Member(m),
+            _ => throw new ArgumentOutOfRangeException(nameof(member)),
+        };
+
     public SignatureWriter Member(Type type)
     {
         type = type.UnwrapConstruction();

--- a/src/ClassExplorer/Signatures/AllOfSignature.cs
+++ b/src/ClassExplorer/Signatures/AllOfSignature.cs
@@ -4,15 +4,15 @@ using System.Reflection;
 
 namespace ClassExplorer.Signatures
 {
-    internal sealed class AllOfTypeSignature : TypeSignature
+    internal sealed class AllOfTypeSignature : UniversialSignature
     {
-        internal AllOfTypeSignature(ImmutableArray<ITypeSignature> elements)
+        internal AllOfTypeSignature(ImmutableArray<ISignature> elements)
         {
             Poly.Assert(!elements.IsDefaultOrEmpty);
             Elements = elements;
         }
 
-        public ImmutableArray<ITypeSignature> Elements { get; }
+        public ImmutableArray<ISignature> Elements { get; }
 
         public override bool IsMatch(ParameterInfo parameter)
         {
@@ -39,23 +39,12 @@ namespace ClassExplorer.Signatures
 
             return true;
         }
-    }
 
-    internal sealed class AllOfMemberSignature : MemberSignature
-    {
-        internal AllOfMemberSignature(ImmutableArray<IMemberSignature> elements)
-        {
-            Poly.Assert(!elements.IsDefaultOrEmpty);
-            Elements = elements;
-        }
-
-        public ImmutableArray<IMemberSignature> Elements { get; }
-
-        public override bool IsMatch(MemberInfo member)
+        public override bool IsMatch(MemberInfo subject)
         {
             foreach (IMemberSignature signature in Elements)
             {
-                if (!signature.IsMatch(member))
+                if (!signature.IsMatch(subject))
                 {
                     return false;
                 }

--- a/src/ClassExplorer/Signatures/AnyOfSignature.cs
+++ b/src/ClassExplorer/Signatures/AnyOfSignature.cs
@@ -4,15 +4,15 @@ using System.Reflection;
 
 namespace ClassExplorer.Signatures
 {
-    internal sealed class AnyOfSignature : TypeSignature
+    internal sealed class AnyOfSignature : UniversialSignature
     {
-        internal AnyOfSignature(ImmutableArray<ITypeSignature> elements)
+        internal AnyOfSignature(ImmutableArray<ISignature> elements)
         {
             Poly.Assert(!elements.IsDefaultOrEmpty);
             Elements = elements;
         }
 
-        internal ImmutableArray<ITypeSignature> Elements { get; }
+        internal ImmutableArray<ISignature> Elements { get; }
 
         public override bool IsMatch(ParameterInfo parameter)
         {
@@ -32,6 +32,19 @@ namespace ClassExplorer.Signatures
             foreach (ITypeSignature signature in Elements)
             {
                 if (signature.IsMatch(type))
+                {
+                    return true;
+                }
+            }
+
+            return false;
+        }
+
+        public override bool IsMatch(MemberInfo subject)
+        {
+            foreach (IMemberSignature signature in Elements)
+            {
+                if (signature.IsMatch(subject))
                 {
                     return true;
                 }

--- a/src/ClassExplorer/Signatures/FullMethodSignature.cs
+++ b/src/ClassExplorer/Signatures/FullMethodSignature.cs
@@ -1,0 +1,50 @@
+using System.Collections.Immutable;
+using System.Reflection;
+
+namespace ClassExplorer.Signatures;
+
+internal sealed class FullMethodSignature(ITypeSignature returnType, ImmutableArray<ITypeSignature> parameters) : MemberSignature
+{
+    internal ITypeSignature ReturnType { get; } = returnType;
+
+    internal ImmutableArray<ITypeSignature> Parameters { get; } = parameters;
+
+    public override bool IsMatch(MemberInfo subject)
+    {
+        if (subject is not MethodBase methodBase)
+        {
+            return false;
+        }
+
+        if (subject is ConstructorInfo ctor)
+        {
+            if (!ReturnType.IsMatch(ctor.ReflectedType))
+            {
+                return false;
+            }
+        }
+        else if (subject is MethodInfo method)
+        {
+            if (!ReturnType.IsMatch(method.ReturnParameter))
+            {
+                return false;
+            }
+        }
+
+        ParameterInfo[] parameters = methodBase.GetParameters();
+        if (parameters.Length != Parameters.Length)
+        {
+            return false;
+        }
+
+        for (int i = 0; i < parameters.Length; i++)
+        {
+            if (!Parameters[i].IsMatch(parameters[i]))
+            {
+                return false;
+            }
+        }
+
+        return true;
+    }
+}

--- a/src/ClassExplorer/Signatures/ISignature.cs
+++ b/src/ClassExplorer/Signatures/ISignature.cs
@@ -1,0 +1,18 @@
+using System;
+using System.Reflection;
+
+namespace ClassExplorer.Signatures;
+
+internal interface ISignature : ITypeSignature, IMemberSignature
+{
+    SignatureKind SignatureKind { get; }
+}
+
+[Flags]
+internal enum SignatureKind
+{
+    Invalid = 0,
+    Type = 1 << 0,
+    Member = 1 << 1,
+    Any = Type | Member,
+}

--- a/src/ClassExplorer/Signatures/Keywords.cs
+++ b/src/ClassExplorer/Signatures/Keywords.cs
@@ -39,5 +39,6 @@ namespace ClassExplorer.Signatures
         public const string hasattr = "hasattr";
         public const string number = "number";
         public const string hasdefault = "hasdefault";
+        public const string sig = "sig";
     }
 }

--- a/src/ClassExplorer/Signatures/MemberSignature.cs
+++ b/src/ClassExplorer/Signatures/MemberSignature.cs
@@ -1,9 +1,16 @@
+using System;
 using System.Reflection;
 
 namespace ClassExplorer.Signatures
 {
-    internal abstract class MemberSignature : IMemberSignature
+    internal abstract class MemberSignature : ISignature
     {
+        public SignatureKind SignatureKind => SignatureKind.Member;
+
         public abstract bool IsMatch(MemberInfo subject);
+
+        bool ITypeSignature.IsMatch(ParameterInfo parameter) => false;
+
+        bool ITypeSignature.IsMatch(Type subject) => false;
     }
 }

--- a/src/ClassExplorer/Signatures/TypeSignature.cs
+++ b/src/ClassExplorer/Signatures/TypeSignature.cs
@@ -3,10 +3,14 @@ using System.Reflection;
 
 namespace ClassExplorer.Signatures
 {
-    internal abstract class TypeSignature : ITypeSignature
+    internal abstract class TypeSignature : ISignature
     {
+        public SignatureKind SignatureKind => SignatureKind.Type;
+
         public virtual bool IsMatch(ParameterInfo parameter) => IsMatch(parameter.ParameterType);
 
         public abstract bool IsMatch(Type type);
+
+        bool IMemberSignature.IsMatch(MemberInfo subject) => false;
     }
 }

--- a/src/ClassExplorer/Signatures/UniversialSignature.cs
+++ b/src/ClassExplorer/Signatures/UniversialSignature.cs
@@ -3,13 +3,15 @@ using System.Reflection;
 
 namespace ClassExplorer.Signatures
 {
-    internal abstract class UniversialSignature : ITypeSignature, IMemberSignature
+    internal abstract class UniversialSignature : ISignature
     {
+        public SignatureKind SignatureKind => SignatureKind.Any;
+
         public abstract bool IsMatch(MemberInfo subject);
 
-        public virtual bool IsMatch(ParameterInfo parameter) => IsMatch(parameter.ParameterType);
+        public virtual bool IsMatch(ParameterInfo parameter) => IsMatch((MemberInfo)parameter.ParameterType);
 
-        bool ITypeSignature.IsMatch(Type subject) => IsMatch(subject);
+        public virtual bool IsMatch(Type subject) => IsMatch((MemberInfo)subject);
 
         bool IMemberSignature.IsMatch(MemberInfo subject) => IsMatch(subject);
     }

--- a/src/ClassExplorer/StringMatcher.cs
+++ b/src/ClassExplorer/StringMatcher.cs
@@ -57,6 +57,8 @@ internal sealed class StringMatcher
     {
         // There's a solid chance this isn't actually faster than just branching
         // here, I'll test one day.
+        //
+        // 2025 edit: yeah dude of course branching would be faster this is silly lol
         return _matcher(input, _expected, _pattern);
     }
 


### PR DESCRIPTION
Also add a `sig` member signature to match against a full method signature. Smudge the signature interfaces a bit to make it easier to handle in one class.

This is mostly to make writing some tests a little easier, but it'll also be neat sometimes. Lays some ground work for future member signatures.